### PR TITLE
Update README to specify packages required on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ with the development and to better suit it to the language.
 We highly recommend using a Nimble project to easily add requirements such as
 NimGL.
 
+### Requirements
+
+#### Ubuntu
+
+Install the `xorg-dev` metapackage:
+```sh
+sudo apt xorg-dev
+```
+
 ### Installation
 
 #### With Nimble file (recommended)


### PR DESCRIPTION
I had the same issue mentioned in https://github.com/nimgl/nimgl/issues/14, and either installing `xorg-dev` or individual libraries (`libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev`) got the example code to successfully build.

I don't have access to a Windows & macOS machines right now so I can't test the build on those platforms, but it seems like a good idea to have a requirement list for all of the supported ones.